### PR TITLE
Expose the function clearSession of LISDKSessionManager to allow a proper logout

### DIFF
--- a/LinkedinSwift/LinkedinSwift/sources/LinkedinNativeClient.h
+++ b/LinkedinSwift/LinkedinSwift/sources/LinkedinNativeClient.h
@@ -22,4 +22,9 @@
  */
 - (instancetype)initWithPermissions:(NSArray *)permissions;
 
+/**
+ *  Clear any open session
+ **/
++ (void)clearSession;
+
 @end

--- a/LinkedinSwift/LinkedinSwift/sources/LinkedinNativeClient.m
+++ b/LinkedinSwift/LinkedinSwift/sources/LinkedinNativeClient.m
@@ -64,4 +64,9 @@
     }];
 }
 
+
++ (void)clearSession {
+    [LISDKSessionManager clearSession];
+}
+
 @end


### PR DESCRIPTION
In the `LinkedinNativeClient`, we check if a session is still cached by the LinkedInSDK. This behaviour prevents the User to properly logout from LinkedIn. We need to be able to clear the session saved by the LinkedinSDK.

This fix expose the function `clearSession` from `LISDKSessionManager`. This way, we can manually decide weather or not the User should be redirect to the LinkedIn app.

A current fix for this is to include the LinkedIn SDK into our project which is not ideal.

An other solution would be to expose the `LISDKSessionManager.sharedInstance()` which is not very Swifty.

This would fix the issue 11: https://github.com/tonyli508/LinkedinSwift/issues/11